### PR TITLE
Setting Hetero to 0 for cases when extraHetero is <= 0 and Hetero is never set

### DIFF
--- a/ASCAT/R/ascat.R
+++ b/ASCAT/R/ascat.R
@@ -2380,6 +2380,8 @@ ascat.predictGermlineGenotypes = function(ASCATobj, platform = "AffySNP6") {
     Undecided = sum(is.na(Hom))
     
     extraHetero = round(min(proportionHetero * length(Tumor_BAF_noNA),Undecided-proportionOpen*length(Tumor_BAF_noNA)))
+	
+	Hetero = 0
     
     if(extraHetero>0) {
       


### PR DESCRIPTION
If Hetero is not set in those cases it will cause the following call to fail.
`title = paste(paste(colnames(ASCATobj$Tumor_BAF)[i], Hetero), Homo)` 