### PR TITLE
Fix to case where chromosome has just 1 SNP

### DIFF
--- a/ASCAT/R/ascat.R
+++ b/ASCAT/R/ascat.R
@@ -259,7 +259,8 @@ ascat.GCcorrect = function(ASCATobj, GCcontentfile = NULL) {
         flag_nona<-(complete.cases(td_chr) & complete.cases(GC_newlist_chr))
         
         #only work with chromosomes that have variance
-        if(length(td_chr[flag_nona])>0 & var(td_chr[flag_nona])>0){
+        chr_var=var(td_chr[flag_nona])#Will be NA if there is exactly one element.
+        if(length(td_chr[flag_nona])>0 && !is.na(chr_var) && chr_var>0){
           corr<-cor(GC_newlist_chr[flag_nona,3:ncol(GC_newlist_chr)],td_chr[flag_nona])
           corr_tot<-cbind(corr_tot,corr)
           length_tot<-c(length_tot,length(td_chr))


### PR DESCRIPTION
This change results in ASCAT skipping chromosomes where there is just 1 SNP.  Currently ASCAT attempts to process the chromosome but fails with the error message:

Error in if (length(td_chr[flag_nona]) > 0 & var(td_chr[flag_nona]) >  : 
  missing value where TRUE/FALSE needed

This is because the var function returns a missing value because it requires a vector with at least 2 elements.