### PR TITLE
Add alternative solutions to output from ascat.runAscat()

### DIFF
--- a/ASCAT/R/ascat.runAscat.R
+++ b/ASCAT/R/ascat.runAscat.R
@@ -277,7 +277,6 @@ runASCAT = function(lrr, baf, lrrsegmented, bafsegmented, gender, SNPpos, chromo
 
   if (!failedqualitycheck && is.na(rho_manual)) {
 
-  ###NJB edit 2015-05-05, Saving alternative solutions
 	inv.d <- 1/d
 	alt.ploidy <- cbind(as.numeric(rownames(inv.d)),apply(inv.d,1,max))
 	alt.cellularity <- cbind(as.numeric(colnames(inv.d)),apply(inv.d,2,max))
@@ -290,7 +289,6 @@ runASCAT = function(lrr, baf, lrrsegmented, bafsegmented, gender, SNPpos, chromo
 		rownames(alt.sol) <- 1:nrow(alt.sol)
 		alt.sol[,3] <- (1-((1/alt.sol[,3])/TheoretMaxdist)) * 100
 	}
-	#### end edit
 
     # first, try with all filters
     for (i in 4:(dim(d)[1]-3)) {

--- a/ASCAT/R/ascat.runAscat.R
+++ b/ASCAT/R/ascat.runAscat.R
@@ -107,6 +107,14 @@ ascat.runAscat = function(ASCATobj, gamma = 0.55, pdfPlot = FALSE, y_limit = 5, 
     names(psi) = colnames(n1)
     names(goodnessOfFit) = colnames(n1)
 
+    # Save alternative solutions
+    alternative_solutions_list = list()
+    for (i in 1:length(goodarrays)) {
+      alternative_solutions_list[[i]] = res[[goodarrays[i]]]$alternative_solutions
+    }
+    alternative_solutions <- do.call("rbind", alternative_solutions_list)
+    alternative_solutions <- as.data.frame(alternative_solutions)
+
     seg = NULL
     for (i in 1:length(goodarrays)) {
       segje = res[[goodarrays[i]]]$seg
@@ -177,10 +185,12 @@ ascat.runAscat = function(ASCATobj, gamma = 0.55, pdfPlot = FALSE, y_limit = 5, 
     seg = NULL
     seg_raw = NULL
     distance_matrix = NULL
+    alternative_solutions = NULL
   }
 
   return(list(nA = n1, nB = n2, purity = tp, aberrantcellfraction = tp, ploidy = ploidy, psi = psi, goodnessOfFit = goodnessOfFit,
-              failedarrays = fa, nonaberrantarrays = naarrays, segments = seg, segments_raw = seg_raw, distance_matrix = distance_matrix))
+              failedarrays = fa, nonaberrantarrays = naarrays, segments = seg, segments_raw = seg_raw, distance_matrix = distance_matrix,
+              alternative_solutions = alternative_solutions))
 }
 
 #' @title runASCAT
@@ -266,6 +276,21 @@ runASCAT = function(lrr, baf, lrrsegmented, bafsegmented, gender, SNPpos, chromo
   optima = list()
 
   if (!failedqualitycheck && is.na(rho_manual)) {
+
+  ###NJB edit 2015-05-05, Saving alternative solutions
+	inv.d <- 1/d
+	alt.ploidy <- cbind(as.numeric(rownames(inv.d)),apply(inv.d,1,max))
+	alt.cellularity <- cbind(as.numeric(colnames(inv.d)),apply(inv.d,2,max))
+	alt.p.indx <- which(diff(sign(diff(alt.ploidy[,2]))) == -2) + 1
+	alt.c.indx <- apply(inv.d[rownames(alt.ploidy[alt.p.indx,,drop=F]),,drop=F],1,function(x){ which(x == max(x))})
+	if(length(ascat.runAscat) > 0){
+		alt.sol <- cbind(alt.ploidy[alt.p.indx,1,drop=F], alt.cellularity[alt.c.indx,,drop=F])
+		colnames(alt.sol) <- c('psi_ploidy', 'rho_aberrant_cell_fraction', 'goodness_of_fit')
+		alt.sol <- alt.sol[order(alt.sol[,3],decreasing=T),,drop=F]
+		rownames(alt.sol) <- 1:nrow(alt.sol)
+		alt.sol[,3] <- (1-((1/alt.sol[,3])/TheoretMaxdist)) * 100
+	}
+	#### end edit
 
     # first, try with all filters
     for (i in 4:(dim(d)[1]-3)) {
@@ -742,7 +767,8 @@ runASCAT = function(lrr, baf, lrrsegmented, bafsegmented, gender, SNPpos, chromo
     }
 
     return(list(rho = rho_opt1, psi = psi_opt1, goodnessOfFit = goodnessOfFit_opt1, nonaberrant = nonaberrant,
-                nA = n1all, nB = n2all, seg = seg, seg_raw = seg_raw, distance_matrix = d))
+                nA = n1all, nB = n2all, seg = seg, seg_raw = seg_raw, distance_matrix = d,
+                alternative_solutions = alt.sol))
 
   } else {
 
@@ -753,7 +779,8 @@ runASCAT = function(lrr, baf, lrrsegmented, bafsegmented, gender, SNPpos, chromo
     dev.off()
 
     warning(paste("ASCAT could not find an optimal ploidy and purity value for sample ", name, ".\n", sep=""))
-    return(list(rho = NA, psi = NA, goodnessOfFit = NA, nonaberrant = FALSE, nA = NA, nB = NA, seg = NA, seg_raw = NA, distance_matrix = NA))
+    return(list(rho = NA, psi = NA, goodnessOfFit = NA, nonaberrant = FALSE, nA = NA, nB = NA, seg = NA, seg_raw = NA, distance_matrix = NA,
+    alternative_solutions = NA))
   }
 
 }

--- a/ASCAT/R/ascat.runAscat.R
+++ b/ASCAT/R/ascat.runAscat.R
@@ -274,6 +274,7 @@ runASCAT = function(lrr, baf, lrrsegmented, bafsegmented, gender, SNPpos, chromo
   nropt = 0
   localmin = NULL
   optima = list()
+  alt.sol = data.frame()
 
   if (!failedqualitycheck && is.na(rho_manual)) {
 


### PR DESCRIPTION
Added code written by Prof. Nicolai Juul Birkbak back in 2015 to output all alternative solutions when running `ascat.runAscat()`.

- The alternative solutions are stored as a data.frame in the output object under `alternative_solutions`
- The `alternative_solutions` data.frame outputs `psi_ploidy`, `rho_aberrant_cell_fraction` and `goodness_of_fit`
- The commit should deal with the issue raised [here](https://github.com/VanLoo-lab/ascat/issues/87#issuecomment-1036420679)
- The changes have been tested successfully on 6 WES tumour samples

Session info of the tests:
```
R version 4.5.2 (2025-10-31)
Platform: x86_64-pc-linux-gnu
Running under: Debian GNU/Linux forky/sid

Matrix products: default
BLAS:   /usr/lib/x86_64-linux-gnu/openblas-pthread/libblas.so.3 
LAPACK: /usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblasp-r0.3.30.so;  LAPACK version 3.12.0

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C              
 [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8   
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C                 
 [9] LC_ADDRESS=C               LC_TELEPHONE=C            
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       

time zone: Etc/UTC
tzcode source: system (glibc)

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] ASCAT_3.2.0

loaded via a namespace (and not attached):
 [1] RColorBrewer_1.1-3   codetools_0.2-20     doParallel_1.0.17   
 [4] splines_4.5.2        iterators_1.0.14     parallel_4.5.2      
 [7] BiocGenerics_0.56.0  generics_0.1.4       stats4_4.5.2        
[10] Seqinfo_1.0.0        foreach_1.5.2        GenomicRanges_1.62.0
[13] IRanges_2.44.0       data.table_1.17.8    compiler_4.5.2      
[16] tools_4.5.2          S4Vectors_0.48.0  
```

